### PR TITLE
Recommend Azure instance types

### DIFF
--- a/llm-models/falcon/falcon-7b/01_load_inference.py
+++ b/llm-models/falcon/falcon-7b/01_load_inference.py
@@ -5,9 +5,7 @@
 # MAGIC
 # MAGIC Environment for this notebook:
 # MAGIC - Runtime: 13.1 GPU ML Runtime
-# MAGIC - Instance: `g5.4xlarge` on AWS
-# MAGIC
-# MAGIC GPU instances that have at least 16GB GPU memory would be enough for inference on single input (batch inference requires slightly more memory). On Azure, it is possible to use `Standard_NC6s_v3` or `Standard_NC4as_T4_v3`.
+# MAGIC - Instance: `g5.4xlarge` on AWS, `Standard_NV36ads_A10_v5` on Azure
 
 # COMMAND ----------
 

--- a/llm-models/falcon/falcon-7b/02_mlflow_logging_inference.py
+++ b/llm-models/falcon/falcon-7b/02_mlflow_logging_inference.py
@@ -3,9 +3,7 @@
 # MAGIC # Manage Falcon-7b-instruct model with MLFlow on Databricks
 # MAGIC Environment for this notebook:
 # MAGIC - Runtime: 13.1 GPU ML Runtime
-# MAGIC - Instance: `g5.4xlarge` on AWS
-# MAGIC
-# MAGIC GPU instances that have at least 16GB GPU memory would be enough for inference on single input (batch inference requires slightly more memory). On Azure, it is possible to use `Standard_NC6s_v3` or `Standard_NC4as_T4_v3`.
+# MAGIC - Instance: `g5.4xlarge` on AWS, `Standard_NV36ads_A10_v5` on Azure
 
 # COMMAND ----------
 

--- a/llm-models/falcon/falcon-7b/03_serve_driver_proxy.py
+++ b/llm-models/falcon/falcon-7b/03_serve_driver_proxy.py
@@ -7,9 +7,7 @@
 # MAGIC
 # MAGIC Environment for this notebook:
 # MAGIC - Runtime: 13.1 GPU ML Runtime
-# MAGIC - Instance: `g5.4xlarge` on AWS
-# MAGIC
-# MAGIC GPU instances that have at least 16GB GPU memory would be enough for inference on single input. On Azure, it is possible to use `Standard_NC6s_v3` or `Standard_NC4as_T4_v3`.
+# MAGIC - Instance: `g5.4xlarge` on AWS, `Standard_NV36ads_A10_v5` on Azure
 
 # COMMAND ----------
 

--- a/llm-models/falcon/falcon-7b/04_langchain.py
+++ b/llm-models/falcon/falcon-7b/04_langchain.py
@@ -9,7 +9,9 @@
 # MAGIC
 # MAGIC Environment tested:
 # MAGIC - MLR: 13.1 ML
-# MAGIC - Instance: `i3.xlarge` on AWS for wrapping serving endpoint, `g5.4xlarge` on AWS for wrapping a cluster driver proxy app (same instance as the driver proxy app)
+# MAGIC - Instance:
+# MAGIC   - Wrapping a serving endpoint: `i3.xlarge` on AWS, `Standard_DS3_v2` on Azure
+# MAGIC   - Wrapping a cluster driver proxy app: `g5.4xlarge` on AWS, `Standard_NV36ads_A10_v5` on Azure for wrapping a cluster driver proxy app (same instance as the driver proxy app)
 
 # COMMAND ----------
 

--- a/llm-models/falcon/falcon-7b/05_fine_tune_deepspeed.py
+++ b/llm-models/falcon/falcon-7b/05_fine_tune_deepspeed.py
@@ -6,9 +6,7 @@
 # MAGIC
 # MAGIC Environment tested for this notebook:
 # MAGIC - Runtime: 13.1 GPU ML Runtime
-# MAGIC - Instance: `g5.12xlarge` (4 A10 GPUs) on AWS
-# MAGIC
-# MAGIC On Azure, we suggest using `Standard_NC48ads_A100_v4` on Azure (2 A100-80GB GPUs).
+# MAGIC - Instance: `g5.12xlarge` (4 A10 GPUs) on AWS, `Standard_NC48ads_A100_v4` (2 A100-80GB GPUs) on Azure
 
 # COMMAND ----------
 

--- a/llm-models/llamav2/llamav2-13b/01_load_inference.py
+++ b/llm-models/llamav2/llamav2-13b/01_load_inference.py
@@ -6,7 +6,7 @@
 # MAGIC
 # MAGIC Environment for this notebook:
 # MAGIC - Runtime: 13.2 GPU ML Runtime
-# MAGIC - Instance: `g5.12xlarge` on AWS, `Standard_NC24ads_A100_v4` on Azure
+# MAGIC - Instance: `g5.12xlarge` on AWS, `Standard_NV72ads_A10_v5` or `Standard_NC24ads_A100_v4` on Azure
 # MAGIC
 # MAGIC GPU instances that have at least 2 A10 GPUs would be enough for inference on single input (batch inference requires slightly more memory).
 # MAGIC

--- a/llm-models/llamav2/llamav2-13b/01_load_inference.py
+++ b/llm-models/llamav2/llamav2-13b/01_load_inference.py
@@ -6,11 +6,11 @@
 # MAGIC
 # MAGIC Environment for this notebook:
 # MAGIC - Runtime: 13.2 GPU ML Runtime
-# MAGIC - Instance: `g5.12xlarge` on AWS
+# MAGIC - Instance: `g5.12xlarge` on AWS, `Standard_NC24ads_A100_v4` on Azure
 # MAGIC
 # MAGIC GPU instances that have at least 2 A10 GPUs would be enough for inference on single input (batch inference requires slightly more memory).
 # MAGIC
-# MAGIC requirements:
+# MAGIC Requirements:
 # MAGIC   - To get the access of the model on HuggingFace, please visit the [Meta website](https://ai.meta.com/resources/models-and-libraries/llama-downloads) and accept our license terms and acceptable use policy before submitting this form. Requests will be processed in 1-2 days.
 # MAGIC
 

--- a/llm-models/llamav2/llamav2-13b/02_mlflow_logging_inference.py
+++ b/llm-models/llamav2/llamav2-13b/02_mlflow_logging_inference.py
@@ -6,11 +6,11 @@
 # MAGIC
 # MAGIC Environment for this notebook:
 # MAGIC - Runtime: 13.2 GPU ML Runtime
-# MAGIC - Instance: `g5.12xlarge` on AWS
+# MAGIC - Instance: `g5.12xlarge` on AWS, `Standard_NC24ads_A100_v4` on Azure
 # MAGIC
 # MAGIC GPU instances that have at least 2 A10 GPUs would be enough for inference on single input (batch inference requires slightly more memory).
 # MAGIC
-# MAGIC requirements:
+# MAGIC Requirements:
 # MAGIC - To get the access of the model on HuggingFace, please visit the [Meta website](https://ai.meta.com/resources/models-and-libraries/llama-downloads) and accept our license terms and acceptable use policy before submitting this form. Requests will be processed in 1-2 days.
 
 # COMMAND ----------

--- a/llm-models/llamav2/llamav2-13b/02_mlflow_logging_inference.py
+++ b/llm-models/llamav2/llamav2-13b/02_mlflow_logging_inference.py
@@ -6,7 +6,7 @@
 # MAGIC
 # MAGIC Environment for this notebook:
 # MAGIC - Runtime: 13.2 GPU ML Runtime
-# MAGIC - Instance: `g5.12xlarge` on AWS, `Standard_NC24ads_A100_v4` on Azure
+# MAGIC - Instance: `g5.12xlarge` on AWS, `Standard_NV72ads_A10_v5` or `Standard_NC24ads_A100_v4` on Azure
 # MAGIC
 # MAGIC GPU instances that have at least 2 A10 GPUs would be enough for inference on single input (batch inference requires slightly more memory).
 # MAGIC

--- a/llm-models/llamav2/llamav2-13b/03_serve_driver_proxy.py
+++ b/llm-models/llamav2/llamav2-13b/03_serve_driver_proxy.py
@@ -9,11 +9,11 @@
 # MAGIC
 # MAGIC Environment for this notebook:
 # MAGIC - Runtime: 13.2 GPU ML Runtime
-# MAGIC - Instance: `g5.12xlarge` on AWS
+# MAGIC - Instance: `g5.12xlarge` on AWS, `Standard_NC24ads_A100_v4` on Azure
 # MAGIC
 # MAGIC GPU instances that have at least 2 A10 GPUs would be enough for inference on single input (batch inference requires slightly more memory).
 # MAGIC
-# MAGIC requirements:
+# MAGIC Requirements:
 # MAGIC - To get the access of the model on HuggingFace, please visit the [Meta website](https://ai.meta.com/resources/models-and-libraries/llama-downloads) and accept our license terms and acceptable use policy before submitting this form. Requests will be processed in 1-2 days.
 
 # COMMAND ----------

--- a/llm-models/llamav2/llamav2-13b/03_serve_driver_proxy.py
+++ b/llm-models/llamav2/llamav2-13b/03_serve_driver_proxy.py
@@ -9,7 +9,7 @@
 # MAGIC
 # MAGIC Environment for this notebook:
 # MAGIC - Runtime: 13.2 GPU ML Runtime
-# MAGIC - Instance: `g5.12xlarge` on AWS, `Standard_NC24ads_A100_v4` on Azure
+# MAGIC - Instance: `g5.12xlarge` on AWS, `Standard_NV72ads_A10_v5` or `Standard_NC24ads_A100_v4` on Azure
 # MAGIC
 # MAGIC GPU instances that have at least 2 A10 GPUs would be enough for inference on single input (batch inference requires slightly more memory).
 # MAGIC

--- a/llm-models/llamav2/llamav2-13b/04_langchain.py
+++ b/llm-models/llamav2/llamav2-13b/04_langchain.py
@@ -9,7 +9,9 @@
 # MAGIC
 # MAGIC Environment tested:
 # MAGIC - MLR: 13.2 ML
-# MAGIC - Instance: `i3.xlarge` on AWS for wrapping serving endpoint, `g5.4xlarge` on AWS for wrapping a cluster driver proxy app (same instance as the driver proxy app)
+# MAGIC - Instance:
+# MAGIC   - Wrapping a serving endpoint: `i3.xlarge` on AWS, `Standard_DS3_v2` on Azure
+# MAGIC   - Wrapping a cluster driver proxy app: `g5.12xlarge` on AWS, `Standard_NC24ads_A100_v4` on Azure (same instance as the driver proxy app)
 
 # COMMAND ----------
 

--- a/llm-models/llamav2/llamav2-13b/04_langchain.py
+++ b/llm-models/llamav2/llamav2-13b/04_langchain.py
@@ -11,7 +11,7 @@
 # MAGIC - MLR: 13.2 ML
 # MAGIC - Instance:
 # MAGIC   - Wrapping a serving endpoint: `i3.xlarge` on AWS, `Standard_DS3_v2` on Azure
-# MAGIC   - Wrapping a cluster driver proxy app: `g5.12xlarge` on AWS, `Standard_NC24ads_A100_v4` on Azure (same instance as the driver proxy app)
+# MAGIC   - Wrapping a cluster driver proxy app: `g5.12xlarge` on AWS, `Standard_NV72ads_A10_v5` or `Standard_NC24ads_A100_v4` on Azure (same instance as the driver proxy app)
 
 # COMMAND ----------
 

--- a/llm-models/llamav2/llamav2-13b/06_fine_tune_qlora.py
+++ b/llm-models/llamav2/llamav2-13b/06_fine_tune_qlora.py
@@ -8,7 +8,7 @@
 # MAGIC
 # MAGIC We recommend running this notebook using A100 GPUs. Environment for this notebook:
 # MAGIC - Runtime: 13.2 GPU ML Runtime
-# MAGIC - Instance: `a2-highgpu-1g` on GCP
+# MAGIC - Instance: `a2-highgpu-1g` on GCP, `Standard_NC24ads_A100_v4` on Azure
 # MAGIC
 # MAGIC We will leverage PEFT library from Hugging Face ecosystem, as well as QLoRA for more memory efficient finetuning.
 

--- a/llm-models/llamav2/llamav2-7b/01_load_inference.py
+++ b/llm-models/llamav2/llamav2-7b/01_load_inference.py
@@ -6,12 +6,10 @@
 # MAGIC
 # MAGIC Environment for this notebook:
 # MAGIC - Runtime: 13.2 GPU ML Runtime
-# MAGIC - Instance: `g5.4xlarge` on AWS
+# MAGIC - Instance: `g5.4xlarge` on AWS, `Standard_NV36ads_A10_v5` on Azure
 # MAGIC
-# MAGIC GPU instances that have at least 16GB GPU memory would be enough for inference on single input (batch inference requires slightly more memory). On Azure, it is possible to use `Standard_NC6s_v3` or `Standard_NC4as_T4_v3`.
-# MAGIC
-# MAGIC requirements:
-# MAGIC - To get the access of the model on HuggingFace, please visit the [Meta website](https://ai.meta.com/resources/models-and-libraries/llama-downloads) and accept our license terms and acceptable use policy before submitting this form. Requests will be processed in 1-2 days.
+# MAGIC Requirements:
+# MAGIC - To get the access of the model on HuggingFace, please visit the [Meta website](https://ai.meta.com/resources/models-and-libraries/llama-downloads) and accept the license terms and acceptable use policy before submitting this form. Requests will be processed in 1-2 days.
 
 # COMMAND ----------
 
@@ -140,7 +138,7 @@ def get_num_tokens(text):
 
 print('number of tokens for input:', get_num_tokens(long_input))
 
-results = gen_text([long_input], max_new_tokens=150, use_template=False)
+results = gen_text([long_input], max_new_tokens=150, use_template=True)
 print(results[0])
 
 # COMMAND ----------

--- a/llm-models/llamav2/llamav2-7b/02_mlflow_logging_inference.py
+++ b/llm-models/llamav2/llamav2-7b/02_mlflow_logging_inference.py
@@ -6,11 +6,9 @@
 # MAGIC
 # MAGIC Environment for this notebook:
 # MAGIC - Runtime: 13.2 GPU ML Runtime
-# MAGIC - Instance: `g5.4xlarge` on AWS
+# MAGIC - Instance: `g5.4xlarge` on AWS, `Standard_NV36ads_A10_v5` on Azure
 # MAGIC
-# MAGIC GPU instances that have at least 16GB GPU memory would be enough for inference on single input (batch inference requires slightly more memory). On Azure, it is possible to use `Standard_NC6s_v3` or `Standard_NC4as_T4_v3`.
-# MAGIC
-# MAGIC requirements:
+# MAGIC Requirements:
 # MAGIC - To get the access of the model on HuggingFace, please visit the [Meta website](https://ai.meta.com/resources/models-and-libraries/llama-downloads) and accept our license terms and acceptable use policy before submitting this form. Requests will be processed in 1-2 days.
 
 # COMMAND ----------

--- a/llm-models/llamav2/llamav2-7b/03_serve_driver_proxy.py
+++ b/llm-models/llamav2/llamav2-7b/03_serve_driver_proxy.py
@@ -7,11 +7,9 @@
 # MAGIC
 # MAGIC Environment for this notebook:
 # MAGIC - Runtime: 13.2 GPU ML Runtime
-# MAGIC - Instance: `g5.4xlarge` on AWS
+# MAGIC - Instance: `g5.4xlarge` on AWS, `Standard_NV36ads_A10_v5` on Azure
 # MAGIC
-# MAGIC GPU instances that have at least 16GB GPU memory would be enough for inference on single input. On Azure, it is possible to use `Standard_NC6s_v3` or `Standard_NC4as_T4_v3`.
-# MAGIC
-# MAGIC requirements:
+# MAGIC Requirements:
 # MAGIC - To get the access of the model on HuggingFace, please visit the [Meta website](https://ai.meta.com/resources/models-and-libraries/llama-downloads) and accept our license terms and acceptable use policy before submitting this form. Requests will be processed in 1-2 days.
 
 # COMMAND ----------

--- a/llm-models/llamav2/llamav2-7b/04_langchain.py
+++ b/llm-models/llamav2/llamav2-7b/04_langchain.py
@@ -9,7 +9,9 @@
 # MAGIC
 # MAGIC Environment tested:
 # MAGIC - MLR: 13.2 ML
-# MAGIC - Instance: `i3.xlarge` on AWS for wrapping serving endpoint, `g5.4xlarge` on AWS for wrapping a cluster driver proxy app (same instance as the driver proxy app)
+# MAGIC - Instance:
+# MAGIC   - Wrapping a serving endpoint: `i3.xlarge` on AWS, `Standard_DS3_v2` on Azure
+# MAGIC   - Wrapping a cluster driver proxy app: `g5.4xlarge` on AWS, `Standard_NV36ads_A10_v5` on Azure (same instance as the driver proxy app)
 
 # COMMAND ----------
 

--- a/llm-models/llamav2/llamav2-7b/05_fine_tune_deepspeed.py
+++ b/llm-models/llamav2/llamav2-7b/05_fine_tune_deepspeed.py
@@ -9,9 +9,9 @@
 # MAGIC
 # MAGIC Environment for this notebook:
 # MAGIC - Runtime: 13.2 GPU ML Runtime
-# MAGIC - Instance: `Standard_NC96ads_A100_v4` on Azure with 4 A100 GPUs.
+# MAGIC - Instance: `Standard_NC96ads_A100_v4` on Azure with 4 A100-80GB GPUs
 # MAGIC
-# MAGIC requirements:
+# MAGIC Requirements:
 # MAGIC - To get the access of the model on HuggingFace, please visit the [Meta website](https://ai.meta.com/resources/models-and-libraries/llama-downloads) and accept our license terms and acceptable use policy before submitting this form. Requests will be processed in 1-2 days.
 # MAGIC
 
@@ -48,7 +48,7 @@ notebook_login()
 # COMMAND ----------
 
 # MAGIC %sh
-# MAGIC deepspeed --num_gpus=4 scripts/fine_tune_deepspeed.py
+# MAGIC deepspeed scripts/fine_tune_deepspeed.py
 
 # COMMAND ----------
 

--- a/llm-models/llamav2/llamav2-7b/06_fine_tune_qlora.py
+++ b/llm-models/llamav2/llamav2-7b/06_fine_tune_qlora.py
@@ -8,9 +8,9 @@
 # MAGIC
 # MAGIC Environment for this notebook:
 # MAGIC - Runtime: 13.2 GPU ML Runtime
-# MAGIC - Instance: `g5.8xlarge` on AWS
+# MAGIC - Instance: `g5.8xlarge` on AWS, `Standard_NV36ads_A10_v5` on Azure
 # MAGIC
-# MAGIC We will leverage PEFT library from Hugging Face ecosystem, as well as QLoRA for more memory efficient finetuning
+# MAGIC We leverage the PEFT library from Hugging Face, as well as QLoRA for more memory efficient finetuning.
 
 # COMMAND ----------
 

--- a/llm-models/mpt/mpt-7b/01_load_inference.py
+++ b/llm-models/mpt/mpt-7b/01_load_inference.py
@@ -5,9 +5,7 @@
 # MAGIC
 # MAGIC Environment for this notebook:
 # MAGIC - Runtime: 13.1 GPU ML Runtime
-# MAGIC - Instance: `g5.4xlarge` on AWS
-# MAGIC
-# MAGIC GPU instances that have at least 16GB GPU memory would be enough for inference on single input (batch inference requires slightly more memory). On Azure, it is possible to use `Standard_NC6s_v3` or `Standard_NC4as_T4_v3`.
+# MAGIC - Instance: `g5.4xlarge` on AWS, `Standard_NV36ads_A10_v5` on Azure
 
 # COMMAND ----------
 

--- a/llm-models/mpt/mpt-7b/02_mlflow_logging_inference.py
+++ b/llm-models/mpt/mpt-7b/02_mlflow_logging_inference.py
@@ -4,9 +4,7 @@
 # MAGIC
 # MAGIC Environment for this notebook:
 # MAGIC - Runtime: 13.1 GPU ML Runtime
-# MAGIC - Instance: `g5.4xlarge` on AWS
-# MAGIC
-# MAGIC GPU instances that have at least 16GB GPU memory would be enough for inference on single input (batch inference requires slightly more memory). On Azure, it is possible to use `Standard_NC6s_v3` or `Standard_NC4as_T4_v3`.
+# MAGIC - Instance: `g5.4xlarge` on AWS, `Standard_NV36ads_A10_v5` on Azure
 
 # COMMAND ----------
 

--- a/llm-models/mpt/mpt-7b/03_serve_driver_proxy.py
+++ b/llm-models/mpt/mpt-7b/03_serve_driver_proxy.py
@@ -7,9 +7,7 @@
 # MAGIC
 # MAGIC Environment for this notebook:
 # MAGIC - Runtime: 13.1 GPU ML Runtime
-# MAGIC - Instance: `g5.4xlarge` on AWS
-# MAGIC
-# MAGIC GPU instances that have at least 16GB GPU memory would be enough for inference on single input. On Azure, it is possible to use `Standard_NC6s_v3` or `Standard_NC4as_T4_v3`.
+# MAGIC - Instance: `g5.4xlarge` on AWS, `Standard_NV36ads_A10_v5` on Azure
 
 # COMMAND ----------
 
@@ -124,7 +122,7 @@ from flask import Flask, jsonify, request
 app = Flask("mpt-7b-instruct")
 
 @app.route('/', methods=['POST'])
-def serve_falcon_7b_instruct():
+def serve_mpt_7b_instruct():
   resp = gen_text_for_serving(**request.json)
   return jsonify(resp)
 

--- a/llm-models/mpt/mpt-7b/04_langchain.py
+++ b/llm-models/mpt/mpt-7b/04_langchain.py
@@ -6,7 +6,7 @@
 # MAGIC
 # MAGIC Environment for this notebook:
 # MAGIC - Runtime: 13.1 GPU ML Runtime
-# MAGIC - Instance: `g5.4xlarge` on AWS
+# MAGIC - Instance: `g5.4xlarge` on AWS, `Standard_NV36ads_A10_v5` on Azure (same instance as the driver proxy app)
 
 # COMMAND ----------
 

--- a/llm-models/mpt/mpt-7b/05_fine_tune_deepspeed.py
+++ b/llm-models/mpt/mpt-7b/05_fine_tune_deepspeed.py
@@ -7,7 +7,7 @@
 # MAGIC
 # MAGIC Environment for this notebook:
 # MAGIC - Runtime: 13.1 GPU ML Runtime
-# MAGIC - Instance: `g5.24xlarge` on AWS with 4 A10 GPUs.
+# MAGIC - Instance: `g5.24xlarge` (4 A10 GPUs) on AWS, `Standard_NC24ads_A100_v4` (1 A100-80 GPU) on Azure
 # MAGIC
 
 # COMMAND ----------
@@ -53,7 +53,7 @@ dbutils.library.restartPython()
 # COMMAND ----------
 
 # MAGIC %sh
-# MAGIC deepspeed --num_gpus=4 scripts/fine_tune_deepspeed.py --per-device-train-batch-size=1 --per-device-eval-batch-size=1 --epochs=1 --max-steps=-1 --no-gradient-checkpointing --dbfs-output-dir /dbfs/mpt-7b/
+# MAGIC deepspeed scripts/fine_tune_deepspeed.py --per-device-train-batch-size=1 --per-device-eval-batch-size=1 --epochs=1 --max-steps=-1 --no-gradient-checkpointing --dbfs-output-dir /dbfs/mpt-7b/
 
 # COMMAND ----------
 

--- a/llm-models/xgen/01_load_inference.py
+++ b/llm-models/xgen/01_load_inference.py
@@ -6,7 +6,7 @@
 # MAGIC
 # MAGIC Environment for this notebook:
 # MAGIC - Runtime: 13.2 GPU ML Runtime
-# MAGIC - Instance: `g5.4xlarge` on AWS
+# MAGIC - Instance: `g5.4xlarge` on AWS, `Standard_NV36ads_A10_v5` on Azure
 
 # COMMAND ----------
 

--- a/llm-models/xgen/02_mlflow_logging_inference.py
+++ b/llm-models/xgen/02_mlflow_logging_inference.py
@@ -4,7 +4,7 @@
 # MAGIC
 # MAGIC Environment for this notebook:
 # MAGIC - Runtime: 13.2 GPU ML Runtime
-# MAGIC - Instance: `g5.4xlarge` on AWS
+# MAGIC - Instance: `g5.4xlarge` on AWS, `Standard_NV36ads_A10_v5` on Azure
 
 # COMMAND ----------
 


### PR DESCRIPTION
- Tested Azure instance types and added recommendations for text generation models
- For deepspeed script, omit `--num_gpus=...` because it uses all GPUs by default, and recommended instance types on AWS vs Azure could have different number of GPUs.