### PR TITLE
subtracts input tokens from total in tps calculation

### DIFF
--- a/llm-models/llamav2/llamav2-7b/01_load_inference.py
+++ b/llm-models/llamav2/llamav2-7b/01_load_inference.py
@@ -227,7 +227,7 @@ def get_gen_text_throughput(prompt, use_template=True, **kwargs):
     )
     result = "".join(result)
 
-    return (n_tokens / duration, n_tokens, result)
+    return ((n_tokens - num_input_tokens) / duration, n_tokens, result)
 
 # COMMAND ----------
 


### PR DESCRIPTION
The current version includes the input tokens in the tps calculation, so the long input example in particular appeared to have extremely high throughput (much higher than the shorter input example). (`return_full_text=False` is not honored when `return_tensors=True`)