### PR TITLE
Set HF_HOME before notebook_login

### DIFF
--- a/llm-models/llamav2/llamav2-7b/05_fine_tune_deepspeed.py
+++ b/llm-models/llamav2/llamav2-7b/05_fine_tune_deepspeed.py
@@ -29,18 +29,18 @@
 
 # COMMAND ----------
 
-from huggingface_hub import notebook_login
-
-# Login to Huggingface to get access to the model
-notebook_login()
-
-# COMMAND ----------
-
 import os
 
 os.environ["HF_HOME"] = "/local_disk0/hf"
 os.environ["HF_DATASETS_CACHE"] = "/local_disk0/hf"
 os.environ["TRANSFORMERS_CACHE"] = "/local_disk0/hf"
+
+# COMMAND ----------
+
+from huggingface_hub import notebook_login
+
+# Login to Huggingface to get access to the model
+notebook_login()
 
 # COMMAND ----------
 
@@ -54,7 +54,6 @@ os.environ["TRANSFORMERS_CACHE"] = "/local_disk0/hf"
 # COMMAND ----------
 
 !deepspeed \
---num_gpus=4 \
 scripts/fine_tune_deepspeed.py \
 --final_model_output_path="/dbfs/llm" \
 --output_dir="/local_disk0/output" \


### PR DESCRIPTION
Currently the deepspeed notebook for llamav2 fails the authentication when downloading the model and tokenizer from Hugging Face Hub.

This notebook fix moves `notebook_login()` after `HF_HOME` is set, so that the token is saved to the same location (under `$HF_HOME`) as the Python script.