### PR TITLE
Update llama 7b revision

### DIFF
--- a/llm-models/llamav2/llamav2-7b/01_load_inference.py
+++ b/llm-models/llamav2/llamav2-7b/01_load_inference.py
@@ -33,7 +33,7 @@ import torch
 
 # it is suggested to pin the revision commit hash and not change it for reproducibility because the uploader might change the model afterwards; you can find the commmit history of llamav2-7b-chat in https://huggingface.co/meta-llama/Llama-2-7b-chat-hf/commits/main
 model = "meta-llama/Llama-2-7b-chat-hf"
-revision = "0ede8dd71e923db6258295621d817ca8714516d4"
+revision = "08751db2aca9bf2f7f80d2e516117a53d7450235"
 
 tokenizer = AutoTokenizer.from_pretrained(model, padding_side="left")
 pipeline = transformers.pipeline(

--- a/llm-models/llamav2/llamav2-7b/02_[chat]_mlflow_logging_inference.py
+++ b/llm-models/llamav2/llamav2-7b/02_[chat]_mlflow_logging_inference.py
@@ -32,7 +32,7 @@ notebook_login()
 
 # it is suggested to pin the revision commit hash and not change it for reproducibility because the uploader might change the model afterwards; you can find the commmit history of llamav2-7b-chat in https://huggingface.co/meta-llama/Llama-2-7b-chat-hf/commits/main
 model = "meta-llama/Llama-2-7b-chat-hf"
-revision = "0ede8dd71e923db6258295621d817ca8714516d4"
+revision = "08751db2aca9bf2f7f80d2e516117a53d7450235"
 
 from huggingface_hub import snapshot_download
 

--- a/llm-models/llamav2/llamav2-7b/02_mlflow_logging_inference.py
+++ b/llm-models/llamav2/llamav2-7b/02_mlflow_logging_inference.py
@@ -32,7 +32,7 @@ notebook_login()
 
 # it is suggested to pin the revision commit hash and not change it for reproducibility because the uploader might change the model afterwards; you can find the commmit history of llamav2-7b-chat in https://huggingface.co/meta-llama/Llama-2-7b-chat-hf/commits/main
 model = "meta-llama/Llama-2-7b-chat-hf"
-revision = "0ede8dd71e923db6258295621d817ca8714516d4"
+revision = "08751db2aca9bf2f7f80d2e516117a53d7450235"
 
 from huggingface_hub import snapshot_download
 

--- a/llm-models/llamav2/llamav2-7b/03_[chat]_serve_driver_proxy.py
+++ b/llm-models/llamav2/llamav2-7b/03_[chat]_serve_driver_proxy.py
@@ -34,7 +34,7 @@ import torch
 
 # it is suggested to pin the revision commit hash and not change it for reproducibility because the uploader might change the model afterwards; you can find the commmit history of llamav2-7b-chat in https://huggingface.co/meta-llama/Llama-2-7b-chat-hf/commits/main
 model = "meta-llama/Llama-2-7b-chat-hf"
-revision = "0ede8dd71e923db6258295621d817ca8714516d4"
+revision = "08751db2aca9bf2f7f80d2e516117a53d7450235"
 
 tokenizer = AutoTokenizer.from_pretrained(model, padding_side="left")
 model = AutoModelForCausalLM.from_pretrained(

--- a/llm-models/llamav2/llamav2-7b/03_serve_driver_proxy.py
+++ b/llm-models/llamav2/llamav2-7b/03_serve_driver_proxy.py
@@ -34,7 +34,7 @@ import torch
 
 # it is suggested to pin the revision commit hash and not change it for reproducibility because the uploader might change the model afterwards; you can find the commmit history of llamav2-7b-chat in https://huggingface.co/meta-llama/Llama-2-7b-chat-hf/commits/main
 model = "meta-llama/Llama-2-7b-chat-hf"
-revision = "0ede8dd71e923db6258295621d817ca8714516d4"
+revision = "08751db2aca9bf2f7f80d2e516117a53d7450235"
 
 tokenizer = AutoTokenizer.from_pretrained(model)
 pipeline = transformers.pipeline(


### PR DESCRIPTION
Addresses https://github.com/databricks/databricks-ml-examples/issues/70

The older revision of the model has size ~27GB and was partitioned into 3 binaries; Hugging Face updated the binaries later with total size ~13GB and 2 binary files.

Screenshot of logged artifacts with new revision:
![image](https://github.com/databricks/databricks-ml-examples/assets/12763339/dfbb42c6-0525-4b18-ab3f-ed8a2605daf1)


Tested notebook 02 MLflow save and load to confirm it works the same.