### PR TITLE
Remove cuda specification in logged torch version

### DIFF
--- a/llm-models/llamav2/llamav2-13b/05_fine_tune_deepspeed.py
+++ b/llm-models/llamav2/llamav2-13b/05_fine_tune_deepspeed.py
@@ -183,12 +183,13 @@ input_example=pd.DataFrame({
 
 # Log the model with its details such as artifacts, pip requirements and input example
 # This may take about 1.2 minutes to complete
+torch_version = torch.__version__.split("+")[0]
 with mlflow.start_run() as run:  
     mlflow.pyfunc.log_model(
         "model",
         python_model=LlamaV2(),
         artifacts={'repository' : "/dbfs/llm/llama2-13b-fine-tune/"},
-        pip_requirements=[f"torch=={torch.__version__}", 
+        pip_requirements=[f"torch=={torch_version}", 
                           f"transformers=={transformers.__version__}", 
                           f"accelerate=={accelerate.__version__}", "einops", "sentencepiece"],
         input_example=input_example,

--- a/llm-models/llamav2/llamav2-7b/05_fine_tune_deepspeed.py
+++ b/llm-models/llamav2/llamav2-7b/05_fine_tune_deepspeed.py
@@ -172,12 +172,13 @@ input_example=pd.DataFrame({
 
 # Log the model with its details such as artifacts, pip requirements and input example
 # This may take about 12 minutes to complete
+torch_version = torch.__version__.split("+")[0]
 with mlflow.start_run() as run:  
     mlflow.pyfunc.log_model(
         "model",
         python_model=LlamaV2(),
         artifacts={'repository' : "/dbfs/llm"},
-        pip_requirements=[f"torch=={torch.__version__}", 
+        pip_requirements=[f"torch=={torch_version}", 
                           f"transformers=={transformers.__version__}", 
                           f"accelerate=={accelerate.__version__}", "einops", "sentencepiece"],
         input_example=input_example,

--- a/llm-models/mpt/mpt-30b/02_mlflow_logging_inference.py
+++ b/llm-models/mpt/mpt-30b/02_mlflow_logging_inference.py
@@ -129,12 +129,13 @@ input_example=pd.DataFrame({
 
 # Log the model with its details such as artifacts, pip requirements and input example
 # This may take about 20 minutes to complete
+torch_version = torch.__version__.split("+")[0]
 with mlflow.start_run() as run:  
     mlflow.pyfunc.log_model(
         "model",
         python_model=MPT(),
         artifacts={'repository' : model_location},
-        pip_requirements=[f"torch=={torch.__version__}", 
+        pip_requirements=[f"torch=={torch_version}", 
                           f"transformers=={transformers.__version__}", 
                           f"accelerate=={accelerate.__version__}", "einops", "sentencepiece", "xformers"],
         input_example=input_example,

--- a/llm-models/mpt/mpt-7b/02_mlflow_logging_inference.py
+++ b/llm-models/mpt/mpt-7b/02_mlflow_logging_inference.py
@@ -142,12 +142,13 @@ input_example=pd.DataFrame({
 
 # Log the model with its details such as artifacts, pip requirements and input example
 # This may take about 5 minutes to complete
+torch_version = torch.__version__.split("+")[0]
 with mlflow.start_run() as run:  
     mlflow.pyfunc.log_model(
         "model",
         python_model=MPT(),
         artifacts={'repository' : model_location},
-        pip_requirements=[f"torch=={torch.__version__}", 
+        pip_requirements=[f"torch=={torch_version}", 
                           f"transformers=={transformers.__version__}", 
                           f"accelerate=={accelerate.__version__}", "einops", "sentencepiece"],
         input_example=input_example,

--- a/llm-models/mpt/mpt-7b/05_fine_tune_deepspeed.py
+++ b/llm-models/mpt/mpt-7b/05_fine_tune_deepspeed.py
@@ -152,12 +152,13 @@ input_example=pd.DataFrame({
 
 # Log the model with its details such as artifacts, pip requirements and input example
 # This may take about 12 minutes to complete
+torch_version = torch.__version__.split("+")[0]
 with mlflow.start_run() as run:  
     mlflow.pyfunc.log_model(
         "model",
         python_model=MPT(),
         artifacts={'repository' : "/dbfs/mpt-7b"},
-        pip_requirements=[f"torch=={torch.__version__}", 
+        pip_requirements=[f"torch=={torch_version}", 
                           f"transformers=={transformers.__version__}", 
                           f"accelerate=={accelerate.__version__}", "einops", "sentencepiece"],
         input_example=input_example,


### PR DESCRIPTION
`torch.__version__` on Databricks runtime has CUDA specification (e.g. '1.13.1+cu117'), which needs to be downloaded from the 3rd party pip repo https://download.pytorch.org/whl/torch. The databricks model serving now only downloads all dependencies from pypi registry, so a dependency like `torch==1.31.1+cu117` will cause error in model serving. This PR removes the CUDA specification part in the dependency to ensure the model will work with model serving.