### PR TITLE
Add use cache mpt30b

### DIFF
--- a/llm-models/mpt/mpt-30b/01_load_inference.py
+++ b/llm-models/mpt/mpt-30b/01_load_inference.py
@@ -54,7 +54,11 @@ import torch
 name = "mosaicml/mpt-30b-instruct"
 revision = "2abf1163dd8c9b11f07d805c06e6ec90a1f2037e"
 
-config = transformers.AutoConfig.from_pretrained(name, trust_remote_code=True)
+config = transformers.AutoConfig.from_pretrained(
+  name, 
+  revision=revision, 
+  trust_remote_code=True
+)
 config.max_seq_len = 16384
 config.init_device = 'cuda' # For fast initialization directly on GPU!
 

--- a/llm-models/mpt/mpt-30b/01_load_inference.py
+++ b/llm-models/mpt/mpt-30b/01_load_inference.py
@@ -94,6 +94,7 @@ def generate_text(prompt, **kwargs):
         {
             "pad_token_id": tokenizer.eos_token_id,
             "eos_token_id": tokenizer.eos_token_id,
+            "use_cache": True, # make sure we use kv cache for lowest latency
         }
     )
   


### PR DESCRIPTION
The current example for MPT-30b inference does not work because we provide the revision parameter only when loading the model but not when loading the config from the pre-trained model. So I added the revisions parameter to the arguments for the `transformers.AutoConfig.from_pretrained` method.

Another issue is that the config loaded from the pretrained model has `use_cache=False` which we then use for inference. This will overwrite the default behaviour of using the kv cache for inference and significantly increase latency. So I added `use_cache=True` to the `generate_text` function