### PR TITLE
Add fine-tuning example for bge-v1.5 from marketplace

### DIFF
--- a/llm-models/embedding/bge/bge-large-v1.5/01_load_inference.py
+++ b/llm-models/embedding/bge/bge-large-v1.5/01_load_inference.py
@@ -1,0 +1,87 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC # Run `bge-large-en-v1.5` Embedding on Databricks
+# MAGIC
+# MAGIC [bge-large-en-v1.5 (BAAI General Embedding) model](https://huggingface.co/BAAI/bge-large-en-v1.5) can map any text to a low-dimensional dense vector which can be used for tasks like retrieval, classification, clustering, or semantic search. And it also can be used in vector database for LLMs.
+# MAGIC
+# MAGIC Environment for this notebook:
+# MAGIC - Runtime: 14.1 GPU ML Runtime
+# MAGIC - Instance: `g4dn.xlarge` on AWS or `Standard_NC4as_T4_v3` on Azure
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ### Using Sentence-Transformers
+# MAGIC
+# MAGIC You can use sentence-transformers with the bge-large-en model to encode sentences as embeddings.
+
+# COMMAND ----------
+
+from sentence_transformers import SentenceTransformer, util
+
+
+model_name = "BAAI/bge-large-en-v1.5"
+model = SentenceTransformer(model_name)
+
+
+sentences = ["A man is eating food.",
+  "A man is eating a piece of bread.",
+  "The girl is carrying a baby.",
+  "A man is riding a horse.",
+  "A woman is playing violin.",
+  "Two men pushed carts through the woods.",
+  "A man is riding a white horse on an enclosed ground.",
+  "A monkey is playing drums.",
+  "Someone in a gorilla costume is playing a set of drums.",
+]
+embeddings = model.encode(sentences, normalize_embeddings=True)
+
+cos_sim = util.cos_sim(embeddings, embeddings)
+print("Cosine-Similarity:", cos_sim)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC For s2p (short query to long passage) retrieval task, each short query should start with an instruction `Represent this sentence for searching relevant passages:` for `bge` models.
+
+# COMMAND ----------
+
+instruction = "Represent this sentence for searching relevant passages: "
+
+queries = ["What type of organism is commonly used in preparation of foods such as cheese and yogurt?"]
+passages = [
+  "Mesophiles grow best in moderate temperature, typically between 25°C and 40°C (77°F and 104°F). Mesophiles are often found living in or on the bodies of humans or other animals. The optimal growth temperature of many pathogenic mesophiles is 37°C (98°F), the normal human body temperature. Mesophilic organisms have important uses in food preparation, including cheese, yogurt, beer and wine.", 
+  "Without Coriolis Effect the global winds would blow north to south or south to north. But Coriolis makes them blow northeast to southwest or the reverse in the Northern Hemisphere. The winds blow northwest to southeast or the reverse in the southern hemisphere.",
+  "Summary Changes of state are examples of phase changes, or phase transitions. All phase changes are accompanied by changes in the energy of a system. Changes from a more-ordered state to a less-ordered state (such as a liquid to a gas) areendothermic. Changes from a less-ordered state to a more-ordered state (such as a liquid to a solid) are always exothermic. The conversion of a solid to a liquid is called fusion (or melting). The energy required to melt 1 mol of a substance is its enthalpy of fusion (ΔHfus). The energy change required to vaporize 1 mol of a substance is the enthalpy of vaporization (ΔHvap). The direct conversion of a solid to a gas is sublimation. The amount of energy needed to sublime 1 mol of a substance is its enthalpy of sublimation (ΔHsub) and is the sum of the enthalpies of fusion and vaporization. Plots of the temperature of a substance versus heat added or versus heating time at a constant rate of heating are calledheating curves. Heating curves relate temperature changes to phase transitions. A superheated liquid, a liquid at a temperature and pressure at which it should be a gas, is not stable. A cooling curve is not exactly the reverse of the heating curve because many liquids do not freeze at the expected temperature. Instead, they form a supercooled liquid, a metastable liquid phase that exists below the normal melting point. Supercooled liquids usually crystallize on standing, or adding a seed crystal of the same or another substance can induce crystallization."
+  ]
+query_with_instruction = [instruction+q for q in queries]
+
+q_embeddings = model.encode(query_with_instruction, normalize_embeddings=True)
+p_embeddings = model.encode(passages, normalize_embeddings=True)
+
+scores = util.cos_sim(q_embeddings, p_embeddings)
+print("Cosine-Similarity scores:", scores)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ### Using Langchain
+# MAGIC
+
+# COMMAND ----------
+
+from langchain.embeddings import HuggingFaceBgeEmbeddings
+
+model_kwargs = {'device': 'cuda'}
+encode_kwargs = {'normalize_embeddings': True} # set True to compute cosine similarity
+model_norm = HuggingFaceBgeEmbeddings(
+    model_name=model_name,
+    model_kwargs=model_kwargs,
+    encode_kwargs=encode_kwargs
+)
+
+q_embeddings = model_norm.embed_documents(query_with_instruction)
+p_embeddings = model_norm.embed_documents(passages)
+
+scores = util.cos_sim(q_embeddings, p_embeddings)
+print("Cosine-Similarity scores:", scores)

--- a/llm-models/embedding/bge/bge-large-v1.5/02_mlflow_logging_inference.py
+++ b/llm-models/embedding/bge/bge-large-v1.5/02_mlflow_logging_inference.py
@@ -1,0 +1,148 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC # Manage `bge-large-en-v1.5` model with MLFlow on Databricks
+# MAGIC
+# MAGIC In this example, we demonstrate how to log the [bge-large-en-v1.5 model](https://huggingface.co/BAAI/bge-large-en-v1.5) to MLFLow with the `sentence_transformers` flavor, manage the model with Unity Catalog, and create a model serving endpoint.
+# MAGIC
+# MAGIC Environment for this notebook:
+# MAGIC - Runtime: 14.1 GPU ML Runtime
+# MAGIC - Instance: `g4dn.xlarge` on AWS or `Standard_NC4as_T4_v3` on Azure
+# MAGIC
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Log the model to MLFlow
+
+# COMMAND ----------
+
+from sentence_transformers import SentenceTransformer
+model_name = "BAAI/bge-large-en-v1.5"
+
+model = SentenceTransformer(model_name)
+
+# COMMAND ----------
+
+import mlflow
+import pandas as pd
+
+# Define input and output schema
+sentences = ["This is an example sentence", "Each sentence is converted"]
+signature = mlflow.models.infer_signature(
+    sentences,
+    model.encode(sentences),
+)
+with mlflow.start_run() as run:  
+    mlflow.sentence_transformers.log_model(
+      model, 
+      "bge-embedding", 
+      signature=signature,
+      input_example=sentences)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Register the model to Unity Catalog
+# MAGIC  By default, MLflow registers models in the Databricks workspace model registry. To register models in Unity Catalog instead, we follow the [documentation](https://docs.databricks.com/machine-learning/manage-model-lifecycle/index.html) and set the registry server as Databricks Unity Catalog.
+# MAGIC
+# MAGIC  In order to register a model in Unity Catalog, there are [several requirements](https://docs.databricks.com/machine-learning/manage-model-lifecycle/index.html#requirements), such as Unity Catalog must be enabled in your workspace.
+# MAGIC
+
+# COMMAND ----------
+
+# Configure MLflow Python client to register model in Unity Catalog
+import mlflow
+mlflow.set_registry_uri("databricks-uc")
+
+# COMMAND ----------
+
+# Register model to Unity Catalog
+
+registered_name = "models.default.bge_large_en_v1_5" # Note that the UC model name follows the pattern <catalog_name>.<schema_name>.<model_name>, corresponding to the catalog, schema, and registered model name
+result = mlflow.register_model(
+    "runs:/"+run.info.run_id+"/bge-embedding",
+    registered_name,
+)
+
+# COMMAND ----------
+
+from mlflow import MlflowClient
+client = MlflowClient()
+
+# Choose the right model version registered in the above cell.
+client.set_registered_model_alias(name=registered_name, alias="Champion", version=result.version)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Load the model from Unity Catalog
+
+# COMMAND ----------
+
+import mlflow
+import pandas as pd
+
+loaded_model = mlflow.pyfunc.load_model(f"models:/{registered_name}@Champion")
+
+# Make a prediction using the loaded model
+loaded_model.predict(
+  ["What is ML?", "What is large language model?"],
+)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Create Model Serving Endpoint
+# MAGIC Once the model is registered, we can use API to create a Databricks GPU Model Serving Endpoint that serves the `bge-large-en` model.
+# MAGIC
+# MAGIC Note that the below deployment requires GPU model serving. For more information on GPU model serving, contact the Databricks team or sign up [here](https://docs.google.com/forms/d/1-GWIlfjlIaclqDz6BPODI2j1Xg4f4WbFvBXyebBpN-Y/edit).
+
+# COMMAND ----------
+
+# Provide a name to the serving endpoint
+endpoint_name = 'bge-embedding'
+
+# COMMAND ----------
+
+databricks_url = dbutils.notebook.entry_point.getDbutils().notebook().getContext().apiUrl().getOrElse(None)
+token = dbutils.notebook.entry_point.getDbutils().notebook().getContext().apiToken().getOrElse(None)
+
+# COMMAND ----------
+
+import requests
+import json
+
+deploy_headers = {'Authorization': f'Bearer {token}', 'Content-Type': 'application/json'}
+deploy_url = f'{databricks_url}/api/2.0/serving-endpoints'
+
+model_version = result  # the returned result of mlflow.register_model
+endpoint_config = {
+  "name": endpoint_name,
+  "config": {
+    "served_models": [{
+      "name": f'{model_version.name.replace(".", "_")}_{model_version.version}',
+      "model_name": model_version.name,
+      "model_version": model_version.version,
+      "workload_type": "GPU_SMALL",
+      "workload_size": "Small",
+      "scale_to_zero_enabled": "False"
+    }]
+  }
+}
+endpoint_json = json.dumps(endpoint_config, indent='  ')
+
+# Send a POST request to the API
+deploy_response = requests.request(method='POST', headers=deploy_headers, url=deploy_url, data=endpoint_json)
+
+if deploy_response.status_code != 200:
+  raise Exception(f'Request failed with status {deploy_response.status_code}, {deploy_response.text}')
+
+# Show the response of the POST request
+# When first creating the serving endpoint, it should show that the state 'ready' is 'NOT_READY'
+# You can check the status on the Databricks model serving endpoint page, it is expected to take ~35 min for the serving endpoint to become ready
+print(deploy_response.json())
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC Once the model serving endpoint is ready, you can query it easily with LangChain running in the same workspace.

--- a/llm-models/embedding/bge/bge-large-v1.5/03_build_document_Index.py
+++ b/llm-models/embedding/bge/bge-large-v1.5/03_build_document_Index.py
@@ -1,0 +1,127 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC
+# MAGIC # Build vector database with `bge-large-en-v1.5`
+# MAGIC
+# MAGIC This notebook demostrates how to build a vector store with [faiss](https://github.com/facebookresearch/faiss) using [bge-large-en-v1.5 model](https://huggingface.co/BAAI/bge-large-en-v1.5).
+# MAGIC
+# MAGIC Environment for this notebook:
+# MAGIC - Runtime: 14.1 GPU ML Runtime
+# MAGIC - Instance: `g4dn.xlarge` on AWS or `Standard_NC4as_T4_v3` on Azure.
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Install Required Libraries
+
+# COMMAND ----------
+
+# MAGIC %pip install faiss-gpu==1.7.2
+# MAGIC dbutils.library.restartPython()
+
+# COMMAND ----------
+
+import json
+from datasets import load_dataset
+from langchain.text_splitter import TokenTextSplitter
+from langchain.embeddings import HuggingFaceBgeEmbeddings
+from langchain.vectorstores.faiss import FAISS
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Load the Document data
+# MAGIC
+# MAGIC We will use [peft doc](https://huggingface.co/datasets/smangrul/peft_docs) as an example to build the document database.
+
+# COMMAND ----------
+
+df = load_dataset('smangrul/peft_docs', split='train')
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Prepare Data for Indexing
+# MAGIC
+# MAGIC While there are many fields avaiable in loaded table, the fields that are relevant to build vector database are:
+# MAGIC
+# MAGIC * `chunk_content`: Documentation text
+# MAGIC * `filename`: Filename pointing to the document
+# MAGIC
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC The content available within each doc varies but some documents can be quite long. The process of converting a document to an index involves us translating it to a fixed-size embedding.  An embedding is a set of numerical values, kind of like a coordinate, that summarizes the content in a unit of text. While large embeddings are capable of capturing quite a bit of detail about a document, the larger the document submitted to it, the more the embedding generalizes the content.  It's kind of like asking someone to summarize a paragraph, a chapter or an entire book into a fixed number of dimensions.  The greater the scope, the more the summary must eliminate detail and focus on the higher-level concepts in the text.
+# MAGIC
+# MAGIC A common strategy for dealing with this when generating embeddings is to divide the text into chunks.  These chunks need to be large enough to capture meaningful detail but not so large that key elements get washed out in the generalization.  Its more of an art than a science to determine an appropriate chunk size, but here we'll use a very small chunk size to illustrate what's happening in this step:
+# MAGIC
+
+# COMMAND ----------
+
+chunk_size = 3500
+chunk_overlap = 400
+
+def get_chunks(text):
+  # instantiate tokenization utilities
+  text_splitter = TokenTextSplitter(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
+  
+  # split text into chunks
+  return text_splitter.split_text(text)
+
+df = df.map(lambda example: {"chunks": get_chunks(example["chunk_content"])})
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Create Vector Store
+# MAGIC
+# MAGIC With our data divided into chunks, we are ready to convert these records into searchable embeddings.
+
+# COMMAND ----------
+
+df.set_format("pandas", columns=["filename", "chunks"])
+inputs = df["chunks"]
+
+# COMMAND ----------
+
+df.format
+
+# COMMAND ----------
+
+text_df = df[:].explode('chunks')
+
+# COMMAND ----------
+
+text_inputs = text_df["chunks"].to_list()
+
+model_name = "BAAI/bge-large-en-v1.5"
+model_kwargs = {'device': 'cuda'}
+encode_kwargs = {'normalize_embeddings': True} # set True to compute cosine similarity
+model = HuggingFaceBgeEmbeddings(
+    model_name=model_name,
+    model_kwargs=model_kwargs,
+    encode_kwargs=encode_kwargs
+)
+
+# COMMAND ----------
+
+metadata_inputs = text_df.to_dict(orient='records')
+
+# COMMAND ----------
+
+vector_store = FAISS.from_texts(
+  embedding=model, 
+  texts=text_inputs, 
+  metadatas=metadata_inputs,
+  distance_strategy="COSINE",
+)
+
+# COMMAND ----------
+
+# MAGIC %md 
+# MAGIC In order to user the vector store in other notebooks, we can persist vector to storage:
+
+# COMMAND ----------
+
+vector_store.save_local(folder_path="/dbfs/peft-doc-embed/vector_store")

--- a/llm-models/embedding/bge/bge-large-v1.5/04_fine_tune_embedding.py
+++ b/llm-models/embedding/bge/bge-large-v1.5/04_fine_tune_embedding.py
@@ -1,0 +1,174 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC
+# MAGIC # Fine-Tune `bge-large-en-v1.5` with Sentence Transformers
+# MAGIC
+# MAGIC This notebook demostrates how to fine tune [bge-large-en-v1.5 model](https://huggingface.co/BAAI/bge-large-en-v1.5).
+# MAGIC
+# MAGIC Environment for this notebook:
+# MAGIC - Runtime: 14.1 GPU ML Runtime
+# MAGIC - Instance: `g4dn.xlarge` on AWS or `Standard_NC4as_T4_v3` on Azure
+
+# COMMAND ----------
+
+import json
+from datasets import load_dataset
+
+# COMMAND ----------
+
+output_model_path = "/dbfs/fine_tuned_bge_v1_5_model"
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Prepare your dataset for fine tuning
+# MAGIC
+# MAGIC To fine tune a embedding model for document retrieval, the training data requires a label or structure that allows the model to understand whether two sentences are similar or different. One way is to provide a pair of positive (similar) sentences without a label. For example, pairs of paraphrases, pairs of full texts and their summaries, pairs of duplicate questions, pairs of (query, response).
+# MAGIC
+# MAGIC In this tutorial, we will use [Amazon-QA](https://huggingface.co/datasets/embedding-data/Amazon-QA) as an example to build the training dataset.
+
+# COMMAND ----------
+
+from datasets import load_dataset
+
+# Import the data from Huggingface hub.
+dataset = load_dataset("embedding-data/Amazon-QA", split='train[:500]')
+
+# COMMAND ----------
+
+dataset[2]
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC
+# MAGIC You can see that query (the anchor) has a single sentence, pos (positive) is a list of sentences (the one we print has only one sentence). 
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ### Data preprocessing
+# MAGIC
+# MAGIC Convert the examples into `InputExample`s.
+
+# COMMAND ----------
+
+from sentence_transformers import InputExample
+
+def create_dataset_for_multiple_loss(train_dataset):
+  train_examples = []
+  for elem in train_dataset:
+    query = f"Represent this sentence for searching relevant passages: {elem['query']}"
+    texts = elem["pos"]
+    
+    for text in texts:
+      train_examples.append(InputExample(texts=[query, text]))
+  return train_examples
+
+train_examples = create_dataset_for_multiple_loss(dataset)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC
+# MAGIC ### Fine tune the embedding model
+# MAGIC
+# MAGIC Since we only have sentences pairs with no labels, we can use the `MultipleNegativesRankingLoss` function.
+
+# COMMAND ----------
+
+from sentence_transformers import SentenceTransformer
+model = SentenceTransformer('BAAI/bge-large-en-v1.5')
+
+# COMMAND ----------
+
+from torch.utils.data import DataLoader
+from sentence_transformers import losses
+from accelerate import notebook_launcher
+
+train_dataloader = DataLoader(train_examples, shuffle=True, batch_size=3)
+train_loss = losses.MultipleNegativesRankingLoss(model=model)
+
+model.fit(train_objectives=[(train_dataloader, train_loss)], epochs=3)
+
+# COMMAND ----------
+
+model.save(output_model_path)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Save fine tuned model to mlflow
+
+# COMMAND ----------
+
+# Save the model as Pyfunc to mlflow
+import mlflow
+import torch
+import pandas as pd
+from sentence_transformers import SentenceTransformer
+ 
+class SentenceTransformerEmbeddingModel(mlflow.pyfunc.PythonModel):
+  def load_context(self, context):
+    device = 0 if torch.cuda.is_available() else -1
+    self.model = SentenceTransformer(context.artifacts["sentence-transformer-model"], device=device)
+    
+  def predict(self, context, model_input): 
+    texts = model_input.iloc[:, 0].to_list()  # get the first column
+    sentence_embeddings = self.model.encode(texts)
+    return pd.Series(sentence_embeddings.tolist())
+
+# COMMAND ----------
+
+from mlflow.utils.environment import _mlflow_conda_env
+import accelerate
+import sentence_transformers
+import cloudpickle
+EMBEDDING_CONDA_ENV = _mlflow_conda_env(
+    additional_pip_deps=[
+        f"accelerate=={accelerate.__version__}",
+        f"cloudpickle=={cloudpickle.__version__}",
+        f"sentence-transformers=={sentence_transformers.__version__}",
+    ]
+)
+
+# COMMAND ----------
+
+import mlflow
+
+with mlflow.start_run() as run:
+  my_model = SentenceTransformerEmbeddingModel()
+  model_info = mlflow.pyfunc.log_model(artifact_path="model", python_model=my_model, input_example=["London is known for its finacial district"], artifacts={"sentence-transformer-model": output_model_path}, conda_env=EMBEDDING_CONDA_ENV)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC Run model inference with the model logged in MLFlow.
+
+# COMMAND ----------
+
+import mlflow
+import pandas as pd
+
+# Load model as a PyFuncModel.
+run_id = run.info.run_id
+logged_model = f"runs:/{run_id}/model"
+
+loaded_model = mlflow.pyfunc.load_model(logged_model)
+
+# Predict on a Pandas DataFrame.
+test_df = pd.DataFrame(['London has 9,787,426 inhabitants at the 2011 census',
+              'London is known for its finacial district'], columns=["text"])
+
+loaded_model.predict(test_df)
+
+# COMMAND ----------
+
+# If you need to search the long relevant passages to a short query,
+# you need to add the instruction `Represent this sentence for searching relevant passages:` to the query
+test_df = pd.DataFrame(['London has 9,787,426 inhabitants at the 2011 census',
+                        'London is known for its finacial district'], columns=["text"])
+
+# Add the instruction to each entry in the "text" column
+test_df['text'] = 'Represent this sentence for searching relevant passages: ' + test_df['text']
+loaded_model.predict(test_df)

--- a/llm-models/embedding/bge/bge-large-v1.5/04_fine_tune_embedding_from_marketplace.py
+++ b/llm-models/embedding/bge/bge-large-v1.5/04_fine_tune_embedding_from_marketplace.py
@@ -1,0 +1,197 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC
+# MAGIC # Fine-Tune `bge-large-en-v1.5` with Sentence Transformers
+# MAGIC
+# MAGIC This notebook demostrates how to fine tune [bge-large-en-v1.5 model](https://huggingface.co/BAAI/bge-large-en-v1.5) from Databricks Marketplace.
+# MAGIC
+# MAGIC Environment for this notebook:
+# MAGIC - Runtime: 14.1 GPU ML Runtime
+# MAGIC - Instance: `g4dn.xlarge` on AWS or `Standard_NC4as_T4_v3` on Azure
+
+# COMMAND ----------
+
+import mlflow
+
+# Set mlflow registry to databricks-uc
+mlflow.set_registry_uri("databricks-uc")
+
+# COMMAND ----------
+
+catalog_name = "databricks_bge_v1_5_models" # Default catalog name when installing the model from Databricks Marketplace
+version = 1
+
+model_mlflow_path = f"models:/{catalog_name}.models.bge_large_en_v1_5/{version}"
+
+model_local_path = "/local_disk0/bge_large_en_v1_5/"
+model_output_local_path = "/local_disk0/bge_large_en_v1_5-fine-tune"
+
+# COMMAND ----------
+
+import json
+from datasets import load_dataset
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Prepare your dataset for fine tuning
+# MAGIC
+# MAGIC To fine tune a embedding model for document retrieval, the training data requires a label or structure that allows the model to understand whether two sentences are similar or different. One way is to provide a pair of positive (similar) sentences without a label. For example, pairs of paraphrases, pairs of full texts and their summaries, pairs of duplicate questions, pairs of (query, response).
+# MAGIC
+# MAGIC In this tutorial, we will use [Amazon-QA](https://huggingface.co/datasets/embedding-data/Amazon-QA) as an example to build the training dataset.
+
+# COMMAND ----------
+
+from datasets import load_dataset
+
+# Import the data from Huggingface hub.
+dataset = load_dataset("embedding-data/Amazon-QA", split='train[:500]')
+
+# COMMAND ----------
+
+dataset[2]
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC
+# MAGIC You can see that query (the anchor) has a single sentence, pos (positive) is a list of sentences (the one we print has only one sentence). 
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ### Data preprocessing
+# MAGIC
+# MAGIC Convert the examples into `InputExample`s.
+
+# COMMAND ----------
+
+from sentence_transformers import InputExample
+
+def create_dataset_for_multiple_loss(train_dataset):
+  train_examples = []
+  for elem in train_dataset:
+    query = f"Represent this sentence for searching relevant passages: {elem['query']}"
+    texts = elem["pos"]
+    
+    for text in texts:
+      train_examples.append(InputExample(texts=[query, text]))
+  return train_examples
+
+train_examples = create_dataset_for_multiple_loss(dataset)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC
+# MAGIC ### Fine tune the embedding model
+# MAGIC
+# MAGIC Since we only have sentences pairs with no labels, we can use the `MultipleNegativesRankingLoss` function.
+
+# COMMAND ----------
+
+from mlflow.artifacts import download_artifacts
+
+path = download_artifacts(artifact_uri=model_mlflow_path, dst_path=model_local_path)
+
+# COMMAND ----------
+
+from sentence_transformers import SentenceTransformer
+import os
+
+sentence_transformer_local_path = os.path.join(path, "model.sentence_transformer")
+
+model = SentenceTransformer(sentence_transformer_local_path)
+
+# COMMAND ----------
+
+from torch.utils.data import DataLoader
+from sentence_transformers import losses
+from accelerate import notebook_launcher
+
+train_dataloader = DataLoader(train_examples, shuffle=True, batch_size=3)
+train_loss = losses.MultipleNegativesRankingLoss(model=model)
+
+model.fit(train_objectives=[(train_dataloader, train_loss)], epochs=3)
+
+# COMMAND ----------
+
+model.save(model_output_local_path)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Save fine tuned model to mlflow
+
+# COMMAND ----------
+
+# Save the model as Pyfunc to mlflow
+import mlflow
+import torch
+import pandas as pd
+from sentence_transformers import SentenceTransformer
+ 
+class SentenceTransformerEmbeddingModel(mlflow.pyfunc.PythonModel):
+  def load_context(self, context):
+    device = 0 if torch.cuda.is_available() else -1
+    self.model = SentenceTransformer(context.artifacts["sentence-transformer-model"], device=device)
+    
+  def predict(self, context, model_input): 
+    texts = model_input.iloc[:, 0].to_list()  # get the first column
+    sentence_embeddings = self.model.encode(texts)
+    return pd.Series(sentence_embeddings.tolist())
+
+# COMMAND ----------
+
+from mlflow.utils.environment import _mlflow_conda_env
+import accelerate
+import sentence_transformers
+import cloudpickle
+EMBEDDING_CONDA_ENV = _mlflow_conda_env(
+    additional_pip_deps=[
+        f"accelerate=={accelerate.__version__}",
+        f"cloudpickle=={cloudpickle.__version__}",
+        f"sentence-transformers=={sentence_transformers.__version__}",
+    ]
+)
+
+# COMMAND ----------
+
+import mlflow
+
+with mlflow.start_run() as run:
+  my_model = SentenceTransformerEmbeddingModel()
+  model_info = mlflow.pyfunc.log_model(artifact_path="model", python_model=my_model, input_example=["London is known for its finacial district"], artifacts={"sentence-transformer-model": model_output_local_path}, conda_env=EMBEDDING_CONDA_ENV)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC Run model inference with the model logged in MLFlow.
+
+# COMMAND ----------
+
+import mlflow
+import pandas as pd
+
+# Load model as a PyFuncModel.
+run_id = run.info.run_id
+logged_model = f"runs:/{run_id}/model"
+
+loaded_model = mlflow.pyfunc.load_model(logged_model)
+
+# Predict on a Pandas DataFrame.
+test_df = pd.DataFrame(['London has 9,787,426 inhabitants at the 2011 census',
+              'London is known for its finacial district'], columns=["text"])
+
+loaded_model.predict(test_df)
+
+# COMMAND ----------
+
+# If you need to search the long relevant passages to a short query,
+# you need to add the instruction `Represent this sentence for searching relevant passages:` to the query
+test_df = pd.DataFrame(['London has 9,787,426 inhabitants at the 2011 census',
+                        'London is known for its finacial district'], columns=["text"])
+
+# Add the instruction to each entry in the "text" column
+test_df['text'] = 'Represent this sentence for searching relevant passages: ' + test_df['text']
+loaded_model.predict(test_df)


### PR DESCRIPTION
- The first 4 notebooks are very slightly modified from the `bge-large` folder, and tested in https://adb-7064161269814046.2.staging.azuredatabricks.net/?o=7064161269814046#notebook/1865658076980990/command/1865658076980991. Shall we deprecate the `bge-large` folder since it's kind of a duplicate?
- Notebook for fine-tuning in marketplace tested in https://e2-dogfood-data-marketplace-provider.staging.cloud.databricks.com/?o=1804038168836448#notebook/622362794630131/command/622362794630151