### PR TITLE
Update MLflow logging script for Llama 2 70B

### DIFF
--- a/llm-models/llamav2/llamav2-7b/02_mlflow_logging_inference.py
+++ b/llm-models/llamav2/llamav2-7b/02_mlflow_logging_inference.py
@@ -70,7 +70,7 @@ inference_config = {
 }
 signature = infer_signature(
     model_input=input_example,
-    model_output="Machien Learning is...",
+    model_output="Machine Learning is...",
     params=inference_config
 )
 


### PR DESCRIPTION
- Recommend MLR 14.2 that has the required transformers and mlflow versions
- Use `mlflow.transformers.log_model` instead of pyfunc